### PR TITLE
fix wtform issue

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.7
-RUN pip install 'apache-airflow[postgres]==1.10.14' && pip install dbt==0.15
-RUN pip install SQLAlchemy==1.3.23
+RUN pip install wtforms==2.3.3 && \
+    pip install 'apache-airflow[postgres]==1.10.14' && \
+    pip install dbt==0.15 && \
+    pip install SQLAlchemy==1.3.23
+
 RUN mkdir /project
 COPY scripts_airflow/ /project/scripts/
 


### PR DESCRIPTION
airflow wont start with this error

```
from wtforms.compat import text_type
ModuleNotFoundError: No module named 'wtforms.compat'
```

proposing solution sticking wtform version as described here https://stackoverflow.com/a/69881648