### PR TITLE
fix error due to removal of 'soft_unicode' in module MarkupSafe

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,7 +2,8 @@ FROM python:3.7
 RUN pip install wtforms==2.3.3 && \
     pip install 'apache-airflow[postgres]==1.10.14' && \
     pip install dbt==0.15 && \
-    pip install SQLAlchemy==1.3.23
+    pip install SQLAlchemy==1.3.23 && \
+    pip install MarkupSafe==2.0.1
 
 RUN mkdir /project
 COPY scripts_airflow/ /project/scripts/


### PR DESCRIPTION
When running 'docker compose up', the following error is displayed in the airflow container: ImportError: cannot import name 'soft_unicode' from 'markupsafe'. 

This issue is caused because 'soft_unicode' was removed form MarkupSafe. By downgrading MarkupSafe to version 2.0.1 this problem can be solved.